### PR TITLE
Ensure accounts tests could fail when run.

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -35,7 +35,8 @@ class ReceiversAccountsTest(TestCase):
 
 
     def test_send_invitation_email(self):
-        pass
+        self.skipTest()
+        self.assertTrue(False)
 
 
     def test_create_verification(self):
@@ -48,8 +49,10 @@ class ReceiversAccountsTest(TestCase):
 
 
     def test_send_verification_email(self):
-        pass
+        self.skipTest()
+        self.assertTrue(False)
 
 
     def test_send_password_reset_email(self):
-        pass
+        self.skipTest()
+        self.assertTrue(False)


### PR DESCRIPTION
Writing test stubs that can never fail is more time consuming than leaving a TODO comment and then they lie to you when looking at test module output. 

Drive-by pedantry :car: :nerd_face: