### PR TITLE
Add CSS rule for `:visited`

### DIFF
--- a/static/news.css
+++ b/static/news.css
@@ -42,6 +42,10 @@ tr.spacer {height:1em;}
     text-decoration: none;
 }
 
+.title > a:visited {
+    color: #999;
+}
+
 /* td {border:1px solid red;} */
 
 /* Site layout */
@@ -149,8 +153,8 @@ and (max-width : 750px) {
     td          { font-family:Verdana, Geneva, sans-serif; font-size:12pt; color:#646464; }
     .smaller    { font-size:10pt; }
 
-    button { 
-        background-color: #e3e3e3; 
+    button {
+        background-color: #e3e3e3;
         border: #646464;
         color: #535353;
         padding: 0.8em;
@@ -169,7 +173,7 @@ and (max-width : 750px) {
         border-width: 0 0.2em 0.6em 0.2em;
         border-color: transparent transparent #646464 transparent;
     }
-    
+
     div.arrow-down {
         width: 0;
         height: 0;


### PR DESCRIPTION
Hey there, thanks for the invite! Loving the links so far. I'm a frontend developer that's starting to use more python at work and this resource is awesome.

I just request a small change, communities like Reddit and Hacker News have a `:visited` [pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited) to give a visual hint to an already visited link. 

I propose changing the color of visited links to a lighter grey but feel free to change it if you want, I just think that having a ":visited" selector is essential to a news site.

Here's how my change looks:

![image](https://user-images.githubusercontent.com/7389358/66708564-4a222980-ed20-11e9-8dcb-485d3b24383b.png)

Post # 1 has been visited, post # 2 has not been visited. 

Let me know what you think!
